### PR TITLE
Fix Drivetrain driving commands and RobotMap

### DIFF
--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -38,7 +38,7 @@ public interface RobotMap {
      * Aim Assist Constants
      ****************************************************************************************/
     double TURN_DIV = 24; // Changes the speed that the robot will turn
-    double MOVE_TURN_DIV = 2; // Changes the speed that the robot will turn while moving
+    double MOVE_TURN_DIV = 2; // Changes the speed that the robot will turn while moving (The more it moves, the less it turns)
     /***************************************************************************************
      * Auton Assist Variables
      ****************************************************************************************/

--- a/src/main/java/frc/robot/commands/AutomaticDriveCommand.java
+++ b/src/main/java/frc/robot/commands/AutomaticDriveCommand.java
@@ -15,10 +15,10 @@ public class AutomaticDriveCommand extends AutomaticTurnCommand {
     @Override
     protected void setSpeed() {
         quickTurn = true; // Automatic Drive Uses Quick Turn
-        double Area = LimeLight.getTargetArea();
-        if (Area != 0) {
+        double area = LimeLight.getTargetArea();
+        if (area <= 0.05) {
             // Set speed depending on how far away the goal is
-            speed = RobotMap.MIN_AUTO_SPEED + Math.max(RobotMap.FORWARD_AREA - Area, 0) * RobotMap.AUTO_SPEED_MUL;
+            speed = RobotMap.MIN_AUTO_SPEED + Math.max(RobotMap.FORWARD_AREA - area, 0) * RobotMap.AUTO_SPEED_MUL;
         } else {
             // if no target is found, fall back on gamepad speed
             super.setSpeed();

--- a/src/main/java/frc/robot/commands/AutomaticTurnCommand.java
+++ b/src/main/java/frc/robot/commands/AutomaticTurnCommand.java
@@ -15,8 +15,6 @@ public class AutomaticTurnCommand extends DrivetrainDriveCommand {
     @Override
     protected void initialize() {
         setInterruptible(false);
-        // Enable CV on the limelight
-        LimeLight.setCamMode(LimeLight.CAM_MODE.VISION);
     }
 
     @Override
@@ -24,6 +22,9 @@ public class AutomaticTurnCommand extends DrivetrainDriveCommand {
         // Set the turn value to the joysticks x value
         super.setTurn();
 
+        // Enable CV on the limelight
+        LimeLight.setCamMode(LimeLight.CAM_MODE.VISION);
+        
         // Add corrective values to turn based on how fast the robot is moving
         turn += LimeLight.getTargetXOffset() / (RobotMap.TURN_DIV * Math.max(RobotMap.MOVE_TURN_DIV * speed, 1));
     }

--- a/src/main/java/frc/robot/commands/DrivetrainDriveCommand.java
+++ b/src/main/java/frc/robot/commands/DrivetrainDriveCommand.java
@@ -26,20 +26,27 @@ public class DrivetrainDriveCommand extends Command {
     // Called just before this Command runs the first time
     @Override
     protected void initialize() {
-        LimeLight.setCamMode(LimeLight.CAM_MODE.DRIVER);
+
     }
 
     // Called repeatedly when this Command is scheduled to run
     @Override
     protected void execute() {
+        LimeLight.setCamMode(LimeLight.CAM_MODE.DRIVER);
         setSpeed();
         setTurn();
         updateDrivetrain();
     }
 
-    // Sub commands for each curvature drive variable
-    protected void updateDrivetrain() {
-        Robot.drivetrain.curvatureDrive(speed, turn, quickTurn);
+    protected void setSpeed() {
+        // Reset the speed to prevent this from becoming acceleration
+        speed = 0;
+        // Set speed to the axes of the triggers
+        speed += Math.pow(Robot.oi.driverGamepad.getRawRightTriggerAxis(), 2);
+        speed -= Math.pow(Robot.oi.driverGamepad.getRawLeftTriggerAxis(), 2);
+
+        // Enable Quick Turn if robot is not moving
+        quickTurn = Math.abs(speed) < 0.125;
     }
 
     protected void setTurn() {
@@ -47,13 +54,9 @@ public class DrivetrainDriveCommand extends Command {
         turn = Math.pow(Robot.oi.driverGamepad.getLeftX(), RobotMap.JOYSTICK_SCALAR);
     }
 
-    protected void setSpeed() {
-        // Set speed to the axes of the triggers
-        speed += Math.pow(Robot.oi.driverGamepad.getRawRightTriggerAxis(), 2);
-        speed -= Math.pow(Robot.oi.driverGamepad.getRawLeftTriggerAxis(), 2);
-
-        // Enable Quick Turn if robot is not moving
-        quickTurn = speed < 0.125;
+    // Sub commands for each curvature drive variable
+    protected void updateDrivetrain() {
+        Robot.drivetrain.curvatureDrive(speed, turn, quickTurn);
     }
 
     // Make this return true when this Command no longer needs to run execute()


### PR DESCRIPTION
*DrivetrainDriveCommand
Use absolute value for speed in line 56
Move Limelight.CAM_MODE.DRIVER from initialize
Reorder methods
Reset speed to 0 in execute
*AutomaticTurnCommand
Move setCamMode from initialize
Add comments for MOVE_TURN_DIV
*AutomaticDriveCommand
Add threshold to area != 0
Change Area to area